### PR TITLE
INHEART-213: Tsconfig files update to avoid TS errors

### DIFF
--- a/apps/mobile/src/app/types/index.d.ts
+++ b/apps/mobile/src/app/types/index.d.ts
@@ -1,0 +1,2 @@
+declare module '*.jpg';
+declare module '*.png';

--- a/apps/mobile/tsconfig.app.json
+++ b/apps/mobile/tsconfig.app.json
@@ -2,8 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
-    "types": ["node"],
-    "composite": true
+    "types": ["node"]
   },
   "exclude": [
     "jest.config.ts",
@@ -15,5 +14,5 @@
     "**/*.stories.jsx",
     "**/*.stories.tsx"
   ],
-  "include": ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx"]
+  "include": ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx", "../../libs/ui/**/src/index.ts"]
 }

--- a/apps/mobile/tsconfig.json
+++ b/apps/mobile/tsconfig.json
@@ -10,7 +10,7 @@
     "resolveJsonModule": true
   },
   "files": ["../../node_modules/@nrwl/react-native/typings/svg.d.ts"],
-  "include": ["libs/ui/**/src/index.ts", "libs/ui/**/src/lib/**/*.tsx"],
+  "include": [],
   "references": [
     {
       "path": "./tsconfig.app.json"


### PR DESCRIPTION
Images imported in mobile projects were underlined, as well as components imported from our libraries. It looks like the new nx version (15.0.2) generates files without those errors. I haven't found what is the difference there, but this PR solves at least some of the errors.