### PR TITLE
INHEART-468: Unnecessary API call when bidding with value lower than current max bid

### DIFF
--- a/apps/mobile/src/app/components/ModalBottom/ModalBottom.tsx
+++ b/apps/mobile/src/app/components/ModalBottom/ModalBottom.tsx
@@ -18,8 +18,11 @@ interface ModalBottomProps {
 const ModalBottom = (props: ModalBottomProps) => {
   const { bottomSheet, auction, confirmModal, bid } = props;
   const [enteredValue, setEnteredValue] = useState(`${props.bid + 1}`);
+  const [isDisabled, setIsDisabled] = useState(false);
 
   function bidInputHandler(enteredText: string) {
+    const enteredTextToNumber = parseInt(enteredText);
+    enteredTextToNumber > props.bid ? setIsDisabled(false) : setIsDisabled(true);
     setEnteredValue(enteredText);
   }
 
@@ -54,7 +57,15 @@ const ModalBottom = (props: ModalBottomProps) => {
             />
           </Row>
           <Row justifyContent='center' alignItems='center'>
-            <Button width='90%' marginTop='20px' fontSize='30px' height='50px' onPress={changeBidValue}>
+            <Button
+              width='90%'
+              marginTop='20px'
+              fontSize='30px'
+              height='50px'
+              onPress={changeBidValue}
+              isDisabled={isDisabled}
+              disabled={isDisabled}
+            >
               BID
             </Button>
           </Row>


### PR DESCRIPTION
Disabled bid-button on value lower than current bid;

https://tracker.intive.com/jira/browse/INHEART-468